### PR TITLE
Update node_example.js

### DIFF
--- a/node_example.js
+++ b/node_example.js
@@ -100,7 +100,7 @@ function sample() {
         },
         user_attributes: {"an_attribute_name": "my_attribute_value", "my_number_attribute": "42"},
         session_length: fifteen_minutes,
-        embed_url: "/embed/sso/dashboards/3",
+        embed_url: "/embed/dashboards/3",
         force_logout_login: true
     };
 


### PR DESCRIPTION
Remove "/sso" from embed_url "/sso/" is no longer needed in embed urls and it is not best practice to include "/sso". "/embed/sso" redirects to "/embed".